### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mocha": "^5.2.0",
     "nyc": "^13.0.1",
     "power-assert": "^1.6.0",
-    "prettier": "^1.14.2"
+    "prettier": "^1.14.2",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.