### PR TITLE
fix: correct require in sample code and move to googleapis.dev

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "redis",
   "name_pretty": "Cloud Redis",
   "product_documentation": "https://cloud.google.com/memorystore/docs/redis/",
-  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/redis/latest/",
+  "client_documentation": "https://googleapis.dev/nodejs/redis/latest/",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
   "release_level": "alpha",
   "language": "nodejs",

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-redis/blob/master/LICENSE)
 
-[client-docs]: https://cloud.google.com/nodejs/docs/reference/redis/latest/
+[client-docs]: https://googleapis.dev/nodejs/redis/latest/
 [product-docs]: https://cloud.google.com/memorystore/docs/redis/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project

--- a/src/v1/cloud_redis_client.js
+++ b/src/v1/cloud_redis_client.js
@@ -365,7 +365,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -461,7 +461,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -507,7 +507,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -586,7 +586,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -737,7 +737,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -886,7 +886,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -1009,7 +1009,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -1129,7 +1129,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.
@@ -1244,7 +1244,7 @@ class CloudRedisClient {
    *
    * @example
    *
-   * const redis = require('redis.v1');
+   * const redis = require('@google-cloud/redis');
    *
    * const client = new redis.v1.CloudRedisClient({
    *   // optional auth parameters.

--- a/src/v1/doc/google/protobuf/doc_any.js
+++ b/src/v1/doc/google/protobuf/doc_any.js
@@ -125,7 +125,7 @@
  *   Schemes other than `http`, `https` (or the empty scheme) might be
  *   used with implementation specific semantics.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
  * @typedef Any

--- a/src/v1beta1/doc/google/protobuf/doc_any.js
+++ b/src/v1beta1/doc/google/protobuf/doc_any.js
@@ -125,7 +125,7 @@
  *   Schemes other than `http`, `https` (or the empty scheme) might be
  *   used with implementation specific semantics.
  *
- * @property {string} value
+ * @property {Buffer} value
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
  * @typedef Any

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-05T11:12:08.959832Z",
+  "updateTime": "2019-06-11T20:40:48.013270Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.1",
-        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
+        "version": "0.24.1",
+        "dockerImage": "googleapis/artman@sha256:6018498e15310260dc9b03c9d576608908ed9fbabe42e1494ff3d827fea27b19"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4f3516a6f96dac182973a3573ff5117e8e4f76c7",
-        "internalRef": "251559960"
+        "sha": "701704db786414709d6fd0e85b58a426f9fdd35e",
+        "internalRef": "252688645"
       }
     },
     {


### PR DESCRIPTION
* swaps us over to the new googleapis.dev doc site, so that folks will be able to view fixes to documentation immediately upon publication.
* fix import statements in examples (this has also been fixed upstream in protos, and should find its way into googleapis/googleapis overnight).