### PR TITLE
build: compile protos before running tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "predocs-test": "npm run docs",
-    "prepare": "npm run compile",
+    "prepare": "npm run compile-protos && npm run compile",
     "pretest": "npm run compile",
     "prelint": "cd samples; npm link ../; npm install",
     "clean": "gts clean",


### PR DESCRIPTION
This is required for all libraries, otherwise proto updates will cause synthesis failure (like in #406). Some libraries already have this, some don't; I'll take care of this.
